### PR TITLE
Patched Incorrect Type Name

### DIFF
--- a/human-readable.d.ts
+++ b/human-readable.d.ts
@@ -11,7 +11,7 @@ export type HRSizeType = "BYTE" | "KBYTE" | "MBYTE" | "TBYTE" | "PBYTE";
 
 export function fromBytes(bytes: number, options: HROptionsType): string;
 
-export function calcFromTo(
+export function fromTo(
   bytes: number,
   fromSize: HRSizeType,
   toSize: HRSizeType,

--- a/test/human-readable.test-d.ts
+++ b/test/human-readable.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from 'tsd';
-import { availableSizes, fromBytes, calcFromTo, HROptionsType } from '../human-readable';
+import { availableSizes, fromBytes, fromTo, HROptionsType } from '../human-readable';
 
 const testOptions: HROptionsType = {
     mode: 'IEC',
@@ -10,4 +10,4 @@ expectType<string[]>(availableSizes());
 
 expectType<string>(fromBytes(1024, testOptions));
 
-expectType<string>(calcFromTo(1024, 'KBYTE', 'MBYTE', undefined));
+expectType<string>(fromTo(1024, 'KBYTE', 'MBYTE', undefined));


### PR DESCRIPTION
Changed incorrect type name from `calcFromTo` to `fromTo`.