### PR TITLE
added missing GBYTE in HRSizeType

### DIFF
--- a/human-readable.d.ts
+++ b/human-readable.d.ts
@@ -7,7 +7,7 @@ export interface HROptionsType {
   fullPrecision?: boolean;
   noWhitespace?: boolean;
 }
-export type HRSizeType = "BYTE" | "KBYTE" | "MBYTE" | "TBYTE" | "PBYTE";
+export type HRSizeType = "BYTE" | "KBYTE" | "MBYTE" | "GBYTE" | "TBYTE" | "PBYTE";
 
 export function fromBytes(bytes: number, options: HROptionsType): string;
 


### PR DESCRIPTION
The GBYTE type was missing from the HRSizeType in the type definitions file.

Added so library can be used in ts.

Thanks!